### PR TITLE
fake playResult for Chromecast to show up in results

### DIFF
--- a/api.php
+++ b/api.php
@@ -2865,6 +2865,9 @@
 		$status = $cc->getCastMessage;
 		write_log("Post-Play response: ".$status);
 
+		$return['url'] = 'chromecast://'.$client['host'].':'.$client['port'];
+		$return['status'] = 'success';
+		return $return;
 
 	}
 


### PR DESCRIPTION
Fixes issue of play commands to chromecasts not appearing in results due to playResult being null by faking a url and success message. Should eventually develop a proper fix by getting status of chromecast to ensure successful playback.