### PR TITLE
Rework/Improve CC Detection/Playback

### DIFF
--- a/api.php
+++ b/api.php
@@ -1832,7 +1832,7 @@
 
 	function fetchCastDevices() {
 		if (!(isset($_GET['pollPlayer']))) write_log("Function fired.");
-		$result = Chromecast::scan();
+		$result = Chromecast::scan(30);
 		$returns = array();
 		if (!(isset($_GET['pollPlayer']))) write_log("Returns: ".json_encode($result));
 		foreach ($result as $key=>$value) {
@@ -1840,7 +1840,7 @@
 			$nameString = preg_replace("/\._googlecast.*/","",$key);
 			$nameArray = explode('-',$nameString);
 			$id = array_pop($nameArray);
-			$deviceOut['name'] = $value['fname'];
+			$deviceOut['name'] = $value['friendlyname'];
 			$deviceOut['product'] = 'cast';
 			$deviceOut['id'] = $id;
 			$deviceOut['token'] = 'none';
@@ -2829,18 +2829,13 @@
 		// Set up our cast device
 		$addresses = explode(":",$_SESSION['uri_plexclient']);
 		$client = parse_url($_SESSION['uri_plexclient']);
-		$cc = new Chromecast($client['host'],$client['port']);
-		// Launch the Plex cast app
-		// Is there some way to test if app is already loaded, or check a status before firing this?
-		$cc->launch("9AC194DC");
-		$status = $cc->getStatus;
-		write_log("Launch response: ".$status);
-		// Connect to the Application
-		$cc->connect();
-		$status = $cc->getCastMessage;
-		write_log("Connect response: ".$status);
-		write_log("Sleeping to make sure plex is up and running (not necessary in real app)");
-		sleep(5);
+                try {
+                    $cc = new Chromecast($client['host'],$client['port']);
+                } catch (Exception $e) {
+                    $return['url'] = 'chromecast://'.$client['host'].':'.$client['port'];
+                    $return['status'] = 'Error - Chromecast unresponsive';
+                    return $return;
+                }
 
 		// Build JSON
 		$result = [
@@ -2878,15 +2873,10 @@
 				]
 			]
 		];
-
-		$json = json_encode($result);
-		$status = $cc->sendMessage("urn:x-cast:com.google.cast.media", $json);
-		write_log("Play response: ".$status);
-		sleep(2);
-		$cc->sendMessage("urn:x-cast:plex",'{"type":"PLAY"}');
-		sleep(2);
-		$status = $cc->getCastMessage;
-		write_log("Post-Play response: ".$status);
+                
+                // Launch and play on Plex
+                //write_log("CASTJSONPLAY: " . json_encode($result));
+                $cc->Plex->play(json_encode($result));
 
 		$return['url'] = 'chromecast://'.$client['host'].':'.$client['port'];
 		$return['status'] = 'success';
@@ -3079,42 +3069,37 @@
 	function castCommand($cmd) {
 		// Set up our cast device
 		if (preg_match("/volume/s", $cmd)) {
+                    write_log("::::" . $cmd);
 			$int = filter_var($cmd, FILTER_SANITIZE_NUMBER_INT);
 			$cmd = "volume";
 		}
 		$client = parse_url($_SESSION['uri_plexclient']);
 		$cc = new Chromecast($client['host'],$client['port']);
 
-		// Connect to the Application
-		if ($cmd != 'volume') {
-			$cc->cc_connect();
-			$cc->getStatus();
-			$cc->connect();
-			$cc->getStatus();
-		}
 		$valid = true;
+                write_log("Received CAST COmmand: " . $cmd);
 		switch ($cmd) {
 			case "play":
-				$status= $cc->sendMessage("urn:x-cast:plex",'{"type":"PLAY"}');
+				$cc->Plex->restart();
 				break;
 			case "pause":
-				$status = $cc->sendMessage("urn:x-cast:plex",'{"type":"PAUSE"}');
+                                $cc->Plex->pause();
 				break;
 			case "stepForward":
-				$status = $cc->sendMessage("urn:x-cast:plex",'{"type":"STEPFORWARD"}');
+				$cc->Plex->stepForward();
 				break;
 			case "stop":
-				$status = $cc->sendMessage("urn:x-cast:plex",'{"type":"STOP"}');
+				$cc->Plex->stop();
 				break;
 			case "skipBack":
-				$status = $cc->sendMessage("urn:x-cast:plex",'{"type":"PREVIOUS"}');
+				$cc->Plex->skipBack();
 				break;
 			case "skipForward":
-				$status = $cc->sendMessage("urn:x-cast:plex",'{"type":"NEXT"}');
+				$cc->Plex->skipForward();
 				break;
 			case "volume":
 				write_log("Should be a volume command.");
-				$status = $cc->DMP->SetVolume($int);
+				$cc->Plex->SetVolume($int);
 				break;
 			default:
 				$return['status'] = 'error';

--- a/api.php
+++ b/api.php
@@ -2877,6 +2877,9 @@
                 // Launch and play on Plex
                 //write_log("CASTJSONPLAY: " . json_encode($result));
                 $cc->Plex->play(json_encode($result));
+                sleep(1);
+                fclose($cc->socket);
+                sleep(1);
 
 		$return['url'] = 'chromecast://'.$client['host'].':'.$client['port'];
 		$return['status'] = 'success';
@@ -3106,6 +3109,8 @@
 				$valid = false;
 
 		}
+                fclose($cc->socket);
+                sleep(1);
 
 		if ($valid) {
 			write_log("Command response: ".$status);

--- a/cast/CCPlexPlayer.php
+++ b/cast/CCPlexPlayer.php
@@ -1,0 +1,122 @@
+<?php
+
+// Make it really easy to play videos by providing functions for the Plex Default Media Player
+// Based off the CCDefaultMediaPlayer (as they seem to share functions
+
+require_once("CCBaseSender.php");
+
+class CCPlexPlayer extends CCBaseSender
+{
+	public $appid="9AC194DC";
+	
+	public function play($json) {
+		// Start a playing
+		// First ensure there's an instance of the DMP running
+		$this->launch();
+                
+		$this->chromecast->sendMessage("urn:x-cast:com.google.cast.media", $json);
+		$r = "";
+		while (!preg_match("/\"playerState\":\"PAUSED\"/",$r)) {
+			$r = $this->chromecast->getCastMessage();
+                        //echo $r . "\n";
+			sleep(1);
+		}
+		// Grab the mediaSessionId
+		preg_match("/\"mediaSessionId\":([^\,]*)/",$r,$m);
+		$this->mediaid = $m[1];
+                $this->restart();
+	}
+        
+	public function launch() {
+		// Launch the player or connect to an existing instance if one is already running
+		// First connect to the chromecast
+		$this->chromecast->transportid = "";
+		$this->chromecast->cc_connect();
+		$s = $this->chromecast->getStatus();
+		// Grab the appid
+		preg_match("/\"appId\":\"([^\"]*)/",$s,$m);
+		$appid = $m[1];
+		if ($appid == $this->appid) {
+			// Default Media Receiver is live
+			$this->chromecast->getStatus();
+			$this->chromecast->connect();
+		} else {
+			// Default Media Receiver is not currently live, start it.
+			$this->chromecast->launch($this->appid);
+			$this->chromecast->transportid = "";
+			$r = "";
+			while (!preg_match("/Plex/",$r) && !preg_match("/Default Media Receiver/",$r)) {
+				$r = $this->chromecast->getStatus();
+                                echo $r . "\n";
+				sleep(1);
+			}
+			$this->chromecast->connect();
+		}
+	}
+	
+	public function pause() {
+		// Pause
+		$this->launch(); // Auto-reconnects
+                $this->chromecast->sendMessage("urn:x-cast:plex",'{"type":"PAUSE"}');
+	}
+
+	public function restart() {
+		// Restart (after pause)
+		$this->launch(); // Auto-reconnects
+                $this->chromecast->sendMessage("urn:x-cast:plex",'{"type":"PLAY"}');
+	}
+        
+        public function stepForward() {
+                $this->launch();
+                $this->chromecast->sendMessage("urn:x-cast:plex",'{"type":"STEPFORWARD"}');
+        }
+	
+	public function stop() {
+		// Stop
+		$this->launch(); // Auto-reconnects
+                $this->chromecast->sendMessage("urn:x-cast:plex",'{"type":"STOP"}');
+		//$this->chromecast->getCastMessage();
+	}
+	
+        public function skipBack() {
+                $this->launch();
+                $this->chromecast->sendMessage("urn:x-cast:plex",'{"type":"PREVIOUS"}');
+        }
+        
+        public function skipForward() {
+                $this->launch();
+                $this->chromecast->sendMessage("urn:x-cast:plex",'{"type":"NEXT"}');
+        }
+        
+	public function Mute() {
+		// Mute a video
+		$this->launch(); // Auto-reconnects
+		$this->chromecast->sendMessage("urn:x-cast:com.google.cast.receiver", '{"type":"SET_VOLUME", "volume": { "muted": true }, "requestId":1 }');
+		$this->chromecast->getCastMessage();
+	}
+	
+	public function UnMute() {
+		// Mute a video
+		$this->launch(); // Auto-reconnects
+		$this->chromecast->sendMessage("urn:x-cast:com.google.cast.receiver", '{"type":"SET_VOLUME", "volume": { "muted": false }, "requestId":1 }');
+		$this->chromecast->getCastMessage();
+	}
+	
+	public function SetVolume($volume) {
+		// Mute a video
+		$this->launch(); // Auto-reconnects
+		$this->chromecast->sendMessage("urn:x-cast:com.google.cast.receiver", '{"type":"SET_VOLUME", "volume": { "level": ' . $volume . ' }, "requestId":1 }');
+		//$this->chromecast->getCastMessage();
+	}
+        
+	public function getStatus() {
+		// Stop
+		$this->chromecast->sendMessage("urn:x-cast:com.google.cast.media",'{"type":"GET_STATUS", "mediaSessionId":' . $this->mediaid . ', "requestId":1}');
+		$r = $this->chromecast->getCastMessage();
+		preg_match("/{\"type.*/",$r,$m);
+		return json_decode($m[0]);
+	}
+	
+}
+
+?>

--- a/cast/Chromecast.php
+++ b/cast/Chromecast.php
@@ -1,7 +1,11 @@
 <?php
 
+// Chris Ridings
+// www.chrisridings.com
+
 require_once("CCprotoBuf.php");
 require_once("CCDefaultMediaPlayer.php");
+require_once("CCPlexPlayer.php");
 require_once("mdns.php");
 
 class Chromecast
@@ -15,6 +19,7 @@ class Chromecast
 	public $transportid = ""; // The transportid of our connection
 	public $sessionid = ""; // Session id for any media sessions
 	public $DMP; // Represents an instance of the Default Media Player.
+        public $Plex; // Represents an instance of the Plex player
 	public $lastip = ""; // Store the last connected IP
 	public $lastport; // Store the last connected port
 	public $lastactivetime; // store the time we last did something
@@ -23,8 +28,8 @@ class Chromecast
 
 		// Establish Chromecast connection
 
-		// Don't pay much attention to the Chromecast's certificate.
-		// It'll be for the wrong host address anyway if we
+		// Don't pay much attention to the Chromecast's certificate. 
+		// It'll be for the wrong host address anyway if we 
 		// use port forwarding!
 		$contextOptions = [
 			'ssl' => [
@@ -38,17 +43,29 @@ class Chromecast
 		} else {
 			throw new Exception("Failed to connect to remote Chromecast");
 		}
-
+		
 		$this->lastip = $ip;
 		$this->lastport = $port;
-
+		
 		$this->lastactivetime = time();
-
+		
 		// Create an instance of the DMP for this CCDefaultMediaPlayer
 		$this->DMP = new CCDefaultMediaPlayer($this);
+                $this->Plex = new CCPlexPlayer($this);
 	}
-
-	public static function scan() {
+        
+        public static function scan($wait=15) {
+            // Wrapper for scan
+            $c = 10;
+            $result = array("Error");
+            while ($result[0] == "Error" && $c > 0) {
+                $result = Chromecast::scansub($wait);
+                $c--;
+            }
+            return $result;
+        }
+	
+	public static function scansub($wait=15) {
 		// Performs an mdns scan of the network to find chromecasts and returns an array
 		// Let's test by finding Google Chromecasts
 		$mdns = new mDNS();
@@ -57,13 +74,46 @@ class Chromecast
 		$mdns->query("_googlecast._tcp.local",1,12,"");
 		$mdns->query("_googlecast._tcp.local",1,12,"");
 		$mdns->query("_googlecast._tcp.local",1,12,"");
-		$cc = 20;
+		$cc = $wait;
+                set_time_limit($wait * 2);
 		$chromecasts = array();
+                $additionalscache = array(); // Hold additionalRRs
 		while ($cc>0) {
-			$inpacket = $mdns->readIncoming();
-			//$mdns->printPacket($inpacket);
+                        $inpacket = "";
+                        $breakout = 100;
+                        while ($inpacket == "" && $breakout > 0) {
+                            $inpacket = $mdns->readIncoming();
+                            $f = 0;
+                            if ($inpacket <> "") {
+                                if ($inpacket->packetheader->getQuestions() > 0) {
+                                    $f = 0;
+                                    if ($inpacket->questions[0]->qtype==0) {
+                                        if ($inpacket->questions[0]->qclass==256) {
+                                            $breakout--;
+                                        }
+                                    }
+                                    if ($f==0) { $inpacket = ""; }
+                                }
+                            }
+                            if ($inpacket == "" || $f = 1) { 
+                                usleep(5000);
+                                $mdns->requery(); 
+                            }
+                        }
+                        // If we get here and inpacket is "" then there was an error
+                        if ($inpacket == "") {
+                            return array("Error");
+                        }
 			// If our packet has answers, then read them
+                        //$mdns->printPacket($inpacket);
+                        if ($inpacket->packetheader->getAdditionalRRS()>0) {
+                            // Loop the additional RRs for A records
+                            for ($x=0; $x < sizeof($inpacket->additionalrrs); $x++) {
+                                array_push($additionalscache, $inpacket->additionalrrs[$x]);
+                            }
+                        }
 			if ($inpacket->packetheader->getAnswerRRs()> 0) {
+                     //       $mdns->printPacket($inpacket);
 				for ($x=0; $x < sizeof($inpacket->answerrrs); $x++) {
 					if ($inpacket->answerrrs[$x]->qtype == 12) {
 						//print_r($inpacket->answerrrs[$x]);
@@ -72,48 +122,39 @@ class Chromecast
 							for ($y = 0; $y < sizeof($inpacket->answerrrs[$x]->data); $y++) {
 								$name .= chr($inpacket->answerrrs[$x]->data[$y]);
 							}
-							// The chromecast name is in $name. Send a a SRV query
-							$mdns->query($name, 1, 33, "");
-							$mdns->query($name, 1, 16, "");
-							$cc=60;
+							// The chromecast name is in $name. Send a a SRV query unless it's already in the additionalscache
+                                                        // If it is then swap the additional into the answer and cheat :-)
+                                                        $found = 0;
+                                                        for ($y=0; $y < sizeof($additionalscache); $y++) {
+                                                            if ($additionalscache[$y]->qtype==33) {
+                                                                if ($additionalscache[$y]->name==$name) {
+                                                                    $found = 1;
+                                                                    $inpacket->answerrrs[$x] = $additionalscache[$y];
+                                                                }
+                                                            }
+                                                        }
+                                                        if ($found == 0) {
+                                                            $mdns->query($name, 1, 33, "");
+                                                            $cc=$wait;
+                                                            set_time_limit($wait * 2);
+                                                        }
+ 							// Repeat for text
+                                                        $found = 0;
+                                                        for ($y=0; $y < sizeof($additionalscache); $y++) {
+                                                            if ($additionalscache[$y]->qtype==16) {
+                                                                if ($additionalscache[$y]->name==$name) {
+                                                                    $found = 1;
+                                                                    $inpacket->answerrrs[$x] = $additionalscache[$y];
+                                                                }
+                                                            }
+                                                        }
+                                                        if ($found == 0) {
+                                                            $mdns->query($name, 1, 16, "");
+                                                            $cc=$wait;
+                                                            set_time_limit($wait * 2);
+                                                        }
 						}
 					}
-						if ($inpacket->answerrrs[$x]->qtype == 16) {
-
-							// get target name
-							$offset = 6;
-							$offset++;
-							$target = "";
-							for ($z=0; $z < $size; $z++) {
-								$target .= chr($d[$offset + $z]);
-							}
-							$target .= ".local";
-
-							// get friendly name
-							$a = $inpacket->answerrrs[$x];
-
-							$string = "";
-							for ($x=0; $x < sizeof($a->data); $x++) {
-								$string .= chr($a->data[$x]);
-							}
-							$start = 'fn=';
-							$end = 'ca=';
-							$string = ' ' . $string;
-							$ini = strpos($string, $start);
-							if ($ini == 0) return '';
-							$ini += strlen($start);
-							$len = strpos($string, $end, $ini) - $ini;
-							$fname = substr($string, $ini, $len-1);
-
-							// Loop through the chromecasts and fill in friendly name
-							foreach ($chromecasts as $key=>$value) {
-								if ($value['target'] == $target) {
-									$value['fname'] = $fname;
-									$chromecasts[$key] = $value;
-								}
-							}
-							$cc=60;
-						}
 					if ($inpacket->answerrrs[$x]->qtype == 33) {
 						$d = $inpacket->answerrrs[$x]->data;
 						$port = ($d[4] * 256) + $d[5];
@@ -126,19 +167,60 @@ class Chromecast
 							$target .= chr($d[$offset + $z]);
 						}
 						$target .= ".local";
-						$chromecasts[$inpacket->answerrrs[$x]->name] = array("port"=>$port, "ip"=>"", "target"=>$target);
+						$chromecasts[$inpacket->answerrrs[$x]->name] = array("port"=>$port, "ip"=>"", "target"=>$target, "friendlyname"=>"");
 						// We know the name and port. Send an A query for the IP address
-						$mdns->query($target,1,1,"");
-						$cc=60;
+                                                // or cheat and use the additionalrrs cache if it is present
+                                                $found = 0;
+                                                for ($y=0; $y < sizeof($additionalscache); $y++) {
+                                                    if ($additionalscache[$y]->qtype==1) {
+                                                        if ($additionalscache[$y]->name==$target) {
+                                                            $found = 1;
+                                                            $inpacket->answerrrs[$x] = $additionalscache[$y];
+                                                        }
+                                                    }
+                                                }
+                                                if ($found == 0) {
+                                                    $mdns->query($target,1,1,"");
+                                                    $cc=$wait;
+                                                    set_time_limit($wait * 2);
+                                                }
 					}
+                                        if ($inpacket->answerrrs[$x]->qtype == 16) {
+                                            $fn = "";
+                                            for ($q=0; $q < sizeof($inpacket->answerrrs[$x]->data); $q++) {
+                                                $fn .= chr($inpacket->answerrrs[$x]->data[$q]);
+                                            }
+                                            $stp = strpos($fn,"fn=")+3;
+                                            $etp = strpos($fn,"ca=");
+                                            $fn = substr($fn,$stp,$etp-$stp-1);
+                                            $chromecasts[$inpacket->answerrrs[$x]->name]['friendlyname'] = $fn;
+                                            $found = 0;
+                                            for ($y=0; $y < sizeof($additionalscache); $y++) {
+                                                if ($additionalscache[$y]->qtype==1) {
+                                                    if ($additionalscache[$y]->name==$target) {
+                                                        $found = 1;
+                                                        $inpacket->answerrrs[$x] = $additionalscache[$y];
+                                                    }
+                                                }
+                                            }
+                                            $mdns->query($chromecasts[$inpacket->answerrrs[$x]->name]['target'],1,1,"");
+                                            $cc=$wait;
+                                            set_time_limit($wait * 2);
+                                        }
 					if ($inpacket->answerrrs[$x]->qtype == 1) {
 						$d = $inpacket->answerrrs[$x]->data;
 						$ip = $d[0] . "." . $d[1] . "." . $d[2] . "." . $d[3];
 						// Loop through the chromecasts and fill in the ip
 						foreach ($chromecasts as $key=>$value) {
 							if ($value['target'] == $inpacket->answerrrs[$x]->name) {
-								$value['ip'] = $ip;
+								$value['ip'] = $ip;	
 								$chromecasts[$key] = $value;
+                                                                // If we have an IP address but no friendly name, try and get the friendly name again!
+                                                                if (strlen($value['friendlyname'])<1) {
+                                                                    $mdns->query($key, 1, 16, "");
+                                                                    $cc=$wait;
+                                                                    set_time_limit($wait * 2);
+                                                                }
 							}
 						}
 					}
@@ -146,10 +228,9 @@ class Chromecast
 			}
 			$cc--;
 		}
-
 		return $chromecasts;
 	}
-
+	
 	function testLive() {
 		// If there is a difference of 10 seconds or more between $this->lastactivetime and the current time, then we've been kicked off and need to reconnect
 		if ($this->lastip == "") { return; }
@@ -171,7 +252,7 @@ class Chromecast
 			$this->connect(1);
 		}
 	}
-
+	
 	function cc_connect($tl=0) {
 		// CONNECT TO CHROMECAST
 		// This connects to the chromecast in general.
@@ -189,15 +270,16 @@ class Chromecast
 		fflush($this->socket);
 		$this->lastactivetime = time();
 	}
-
+	
 	public function launch($appid) {
 
 		// Launches the chromecast app on the connected chromecast
 
 		// CONNECT
 		$this->cc_connect();
-
-
+		
+		$this->getStatus();
+		
 		// LAUNCH
 		$c = new CastMessage();
                 $c->source_id = "sender-0";
@@ -210,12 +292,14 @@ class Chromecast
 		$this->lastactivetime = time();
 		$this->requestId++;
 
-		while ($this->transportid == "") {
-			$this->getCastMessage();
+		$oldtransportid = $this->transportid;
+		while ($this->transportid == "" || $this->transportid == $oldtransportid) {
+			$r = $this->getCastMessage();
+			sleep(1);
 		}
 	}
-
-
+	
+	
 	function getStatus() {
 		// Get the status of the chromecast in general and return it
 		// also fills in the transportId of any currently running app
@@ -233,6 +317,7 @@ class Chromecast
 		$r = "";
 		while ($this->transportid == "") {
 			$r = $this->getCastMessage();
+                        echo "_---" . $r . "\n";
 		}
 		return $r;
 	}
@@ -249,7 +334,7 @@ class Chromecast
                 $c->payloadutf8 = '{"type":"CONNECT"}';
                 fwrite($this->socket, $c->encode());
                 fflush($this->socket);
-		$this->lastactivetime = time();
+				$this->lastactivetime = time();
                 $this->requestId++;
 	}
 
@@ -264,6 +349,8 @@ class Chromecast
 			$this->pong();
 			sleep(3);
 			$response = fread($this->socket, 2000);
+                        // Wait infinitely for a packet.
+                        set_time_limit(30);
 		}
 		if (preg_match("/transportId/s", $response)) {
 			preg_match("/transportId\"\:\"([^\"]*)/",$response,$matches);
@@ -310,7 +397,7 @@ class Chromecast
                 $c->payloadutf8 = '{"type":"PING"}';
                 fwrite($this->socket, $c->encode());
                 fflush($this->socket);
-		$this->lastactivetime = time();
+				$this->lastactivetime = time();
                 $this->requestId++;
 		$response = $this->getCastMessage();
 	}


### PR DESCRIPTION
I can only test on one Chromecast, but this modifies as follows:

1. Latest ::scan from the Chromecast library - quicker/more likely to detect chromecasts.
2. Gets friendly name as per TXT record processing method from cwallace
3. Moves the Chromecast Plex control code logic from api.php to cast/CCPlexPlayer.php
4. No longer sleeps before play = hopefully videos no longer start paused (on the assumption that that's based on the timing).