### PR TITLE
Add timeouts to all curls that dont have it

### DIFF
--- a/api.php
+++ b/api.php
@@ -3933,6 +3933,7 @@ function radarrDownload2($command) {
 			write_log("Made it to the next CURL");
 			$content = json_encode($resultObject);
 			$curl = curl_init($putURL);
+			curl_setopt($curl, CURLOPT_TIMEOUT, 2);
 			curl_setopt($curl, CURLOPT_HEADER, false);
 			curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
 			curl_setopt ($curl, CURLOPT_CAINFO, dirname(__FILE__) . "/cert/cacert.pem");
@@ -3958,6 +3959,7 @@ function radarrDownload2($command) {
 				$fetchMe['name'] = 'MovieSearch';
 				$fetchMe['movieId'] = $movieID;
 				$curl = curl_init($scanURL);
+				curl_setopt($curl, CURLOPT_TIMEOUT, 2);
 				curl_setopt($curl, CURLOPT_HEADER, false);
 				curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
 				curl_setopt ($curl, CURLOPT_CAINFO, dirname(__FILE__) . "/cert/cacert.pem");

--- a/body.php
+++ b/body.php
@@ -71,6 +71,7 @@ function makeBody($newToken = false) {
 	$_SESSION['hookCustomReply'] = $config->get('user-_-'.$_SESSION['plexUserName'], 'hookCustomReply', "");
 	$url = 'https://plex.tv/pms/:/ip';
     $ch = curl_init();
+    curl_setopt($ch, CURLOPT_TIMEOUT, 2);
     curl_setopt($ch, CURLOPT_URL,$url);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
     curl_setopt ($ch, CURLOPT_CAINFO, dirname(__FILE__) . "/cert/cacert.pem");

--- a/util.php
+++ b/util.php
@@ -212,6 +212,7 @@ require_once dirname(__FILE__) . '/vendor/autoload.php';
 	function checkRemoteFile($url) {
     	$certPath = file_build_path(dirname(__FILE__),"cert","cacert.pem");
 		$ch = curl_init();
+		curl_setopt($ch, CURLOPT_TIMEOUT, 2);
 		curl_setopt($ch, CURLOPT_URL,$url);
 		curl_setopt ($ch, CURLOPT_CAINFO, $certPath);
 		curl_setopt($ch, CURLOPT_NOBODY, 1);
@@ -832,6 +833,7 @@ function checkGit() {
 /* gets content from a URL via curl */
 function getUrl($url) {
 	$ch = curl_init();
+	curl_setopt($ch, CURLOPT_TIMEOUT, 2);
 	curl_setopt($ch,CURLOPT_URL,$url);
 	curl_setopt($ch,CURLOPT_RETURNTRANSFER,1);
 	curl_setopt($ch,CURLOPT_CONNECTTIMEOUT,5);


### PR DESCRIPTION
I found that my Phlex server was highly unresponsive and barely worked until I added timeouts to a handful of curl requests that didn't have them set.

I believe this was in part due to Phlex trying to fetch the art/thumbnails for movies using bad image URLs (e.g. https://xxx-xxx-xxx-xxx.a58e7badeee847142f4512fa34cdb645.plex.direct:3
2400/library/metadata/-1/art/1452774007?X-Plex-Token=bmKdpBLrdqRNkLHG2Kks, with IP and tokens anonymised).

However the server also seemed to fail on startup sometimes, during the validateCredentials() step.

Either way, things work much better for me with these timeouts in place.