### PR TITLE
Remove duplicate header X-Plex-Target-Client-Identifier...

### DIFF
--- a/api.php
+++ b/api.php
@@ -466,9 +466,6 @@ function setSessionVariables($rescan=true) {
 		'&X-Plex-Device-Name=Phlex'.
 		'&X-Plex-Device-Screen-Resolution=1520x707,1680x1050,1920x1080'.
 		'&X-Plex-Token='.$_SESSION['plexToken'];
-
-	// Q&D Variable with the plex target client header
-	$_SESSION['plexClientHeader']='&X-Plex-Target-Client-Identifier='.$_SESSION['plexClientId'];
 }
 
 // Log our current session variables
@@ -3083,7 +3080,6 @@ function playMediaDirect($media) {
 		'&address=' .$serverIP.
 		'&port=' .$serverPort.
 		'&path='.urlencode($_SESSION['plexServerUri'].'/'.$media['key']).
-		'&X-Plex-Target-Client-Identifier='.$_SESSION['plexClientId'].
 		'&token=' .$transientToken;
 	$status = playerCommand($playUrl);
 	write_log('Playback URL is ' . protectURL($playUrl),"INFO");
@@ -3110,8 +3106,7 @@ function playMediaRelayed($media) {
 		'&port=' .$serverPort.
 		'&containerKey=%2FplayQueues%2F'.$queueID.'%3Fown%3D1%26window%3D200'.
 		'&token=' .$transientToken.
-		'&commandID='.$_SESSION['counter'].
-		clientString();
+		'&commandID='.$_SESSION['counter'];
 	$headers = clientHeaders();
 	$result = curlGet($playUrl,$headers);
 	write_log('Playback URL is ' . protectURL($playUrl));

--- a/util.php
+++ b/util.php
@@ -310,9 +310,9 @@ function flattenXML($xml){
 		$ch = curl_init();
 		curl_setopt($ch, CURLOPT_URL,$url);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $timeout);
-        curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
-		curl_setopt ($ch, CURLOPT_CAINFO, $cert);
+		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $timeout);
+		curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
+		curl_setopt($ch, CURLOPT_CAINFO, $cert);
 		if ($headers !== null) curl_setopt($ch, CURLOPT_HTTPHEADER,$headers);
 		$result = curl_exec($ch);
 		if (!curl_errno($ch)) {
@@ -320,7 +320,7 @@ function flattenXML($xml){
 				case 200:
 					break;
 				default:
-					write_log('Unexpected HTTP code: '. $http_code.', URL: '.$url, "ERROR");
+					write_log('Unexpected HTTP code: '. $http_code.', URL: '. $url .', Headers: '. json_encode($headers) .', Result: '. $result, "ERROR");
 					$result = false;
 			}
 		}


### PR DESCRIPTION
for some playMedia commands, which fixes an issue with playing media to some devices.

Added more verbose logging, including the request headers and response body, in curlGet when there is an error to help with debugging.