### PR TITLE
Wait longer when starting new media via Chromecasts

### DIFF
--- a/api.php
+++ b/api.php
@@ -3229,7 +3229,7 @@ function playMediaCast($media) {
 		];
 		// Launch and play on Plex
 		$cc->Plex->play(json_encode($result));
-		sleep(1);
+		sleep(2);
 		fclose($cc->socket);
 		$return['status'] = 'success';
 	} else {


### PR DESCRIPTION
Wait longer when starting new media via Chromecasts before cleaning up the socket.
This reduces Chromecast error responses in my environment.