### PR TITLE
If we're using FPM, close inbound API connections after sending a speech response

### DIFF
--- a/api.php
+++ b/api.php
@@ -4426,6 +4426,9 @@ function returnSpeech($speech, $contextName, $cards = false, $waitForResponse = 
 	} else {
 		returnAssistantSpeech($speech, $contextName, $cards, $waitForResponse, $suggestions);
 	}
+	if (function_exists('fastcgi_finish_request')) {
+		fastcgi_finish_request();
+	}
 }
 
 // APIAI ITEMS


### PR DESCRIPTION
This reduces the incidence of _Phlex TV is not available_ type timeout induced responses while allowing the requested actions to continue in the background.