### PR TITLE
Fix the big issue everyone seems to be having.

### DIFF
--- a/api.php
+++ b/api.php
@@ -163,7 +163,7 @@ function initialize() {
 		$product = $_GET['product'];
 		if ($id != 'rescan') {
 			write_log('New device selected. Type is ' . $type . ". ID is " . $id . ". Name is " . $name, "INFO");
-			if ($type == 'plexServerId') {
+			if ($type == 'plexServer') {
 				$token = $_GET['token'];
 				$GLOBALS['config']->set('user-_-' . $_SESSION['plexUserName'], $type . 'Token', $token);
 			}


### PR DESCRIPTION
Fixed the misnamed types that is sent from get.
[Main.js - line 243](https://github.com/d8ahazard/Phlex/blob/master/js/main.js#L243): `device: 'plexServer',` is sending "plexServer" as the device type and the logic used in line 166 of this file is expecting PlexServerId.

Fixes issue #247 and probably others.