### PR TITLE
Made Sonarr & Radarr Ports Optional

### DIFF
--- a/api.php
+++ b/api.php
@@ -4315,8 +4315,8 @@ function testConnection($serviceName) {
 			$sonarrPath = $_SESSION['sonarrPath'];
 			$sonarrApikey = $_SESSION['sonarrAuth'];
 			$sonarrPort = $_SESSION['sonarrPort'];
-			if (($sonarrURL) && ($sonarrApikey) && ($sonarrPort)) {
-				$url = $sonarrURL . ":" . $sonarrPort . $sonarrPath . "/api/profile?apikey=" . $sonarrApikey;
+			if (($sonarrURL) && ($sonarrApikey)) {
+				$url = $sonarrURL . ($sonarrPort ? ":" . $sonarrPort : "") . $sonarrPath . "/api/profile?apikey=" . $sonarrApikey;
 				$result = curlGet($url);
 				if ($result) {
 					write_log("Result retrieved.");
@@ -4346,8 +4346,8 @@ function testConnection($serviceName) {
 			$radarrPath = $_SESSION['radarrPath'];
 			$radarrApikey = $_SESSION['radarrAuth'];
 			$radarrPort = $_SESSION['radarrPort'];
-			if (($radarrURL) && ($radarrApikey) && ($radarrPort)) {
-				$url = $radarrURL . ":" . $radarrPort . $radarrPath . "/api/profile?apikey=" . $radarrApikey;
+			if (($radarrURL) && ($radarrApikey)) {
+				$url = $radarrURL . ($radarrPort ? ":" . $radarrPort : "") . $radarrPath . "/api/profile?apikey=" . $radarrApikey;
 				write_log("Request URL: " . $url);
 				$result = curlGet($url);
 				if ($result) {


### PR DESCRIPTION
I use a seedbox and have no control over port settings, and in this case there are none. Therefore this meant that there was no way for me to get Phlex to connect to remote Sonarr and Radarr API endpoints. For example, the following endpoints could never be configured (not real but gives you an understanding of what I am talking about):

`http://super-awesome-seedbox.sonarr.com/` and `http://super-awesome-seedbox.radarr.com/`

I could use the IP instead of the DNS entry, however that could be inconvenient as I have no idea if they use static IPs etc. Therefore the simplest solution was to make the port optional - otherwise I would have to manually update IP addresses periodically.