### PR TITLE
Problem with https ports not running on 443.

### DIFF
--- a/api.php
+++ b/api.php
@@ -3099,7 +3099,12 @@ function playMediaDirect($media) {
 	$server = parse_url($_SESSION['plexServerUri']);
 	$serverProtocol = $server['scheme'];
 	$serverIP = $server['host'];
-	$serverPort = $server['port'] ?: $server['scheme'] === 'https' ? 443 : 80;
+	$serverPort = $server['port'];
+  // previous method of getting port was changing port to 443 and overriding the actual https port.
+  // This method only overrides the port if one was not found in the URI
+  if (empty($serverPort)) {
+	   $serverPort = ($serverProtocol === 'https') ? 443 : 80;
+  }
 	$transientToken = fetchTransientToken();
 	$playUrl = $client . '/player/playback/playMedia' . '?key=' . urlencode($media['key']) . '&offset=' . ($media['viewOffset'] ?? 0) . '&machineIdentifier=' . $serverID . '&protocol=' . $serverProtocol . '&address=' . $serverIP . '&port=' . $serverPort . '&path=' . urlencode($_SESSION['plexServerUri'] . '/' . $media['key']) . '&token=' . $transientToken;
 	$status = playerCommand($playUrl);


### PR DESCRIPTION
My plex server runs https on a high port like 30000.  It was being forced to 443 with the current code.  This prevents the 443 or 80 override from taking place unless the value for port is empty.