### PR TITLE
Add port to callback

### DIFF
--- a/php/util.php
+++ b/php/util.php
@@ -65,7 +65,7 @@ function bye($msg = false, $title = false, $url = false, $log = false, $clear = 
     }
     $actual_link = (isset($_SERVER['HTTPS']) ? "https" : "http") . "://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
     $url = parse_url($actual_link);
-    $url = $url['scheme']."://".$url['host'].$url['path'];
+    $url = $url['scheme']."://".$url['host'].":".$url['port'].$url['path'];
     $url = "$url?device=Client&id=rescan&passive=true&apiToken=".$_SESSION['apiToken'];
     $rescan = $_GET['pollPlayer'] ?? $_GET['passive'] ?? null;
     $executionTime = round(microtime(true) - $_SERVER["REQUEST_TIME_FLOAT"],2)."s";


### PR DESCRIPTION
This seems to be the problem with #399. I use port 5666 with Docker, so the port was required here. 

I'm not quite sure on the workflow that happens when clicking the Link button, but it works for me :)